### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/gen_matrix.py
+++ b/.github/workflows/gen_matrix.py
@@ -1,0 +1,37 @@
+import toml
+import json
+
+packages = toml.load('pkgs.toml')
+defaults = packages['defaults']
+
+PLATFORM_OS_MAP = {
+    'win-64':    {'os': 'windows-latest', 'arch': 'x64'},
+    'osx-arm64': {'os': 'macos-latest',   'arch': 'arm64'},
+    'linux':     {'os': 'ubuntu-latest',  'arch': 'x64'},
+}
+
+arch_include = []
+noarch_include = []
+
+for name, spec in packages.items():
+    if name == 'defaults':
+        continue
+    noarch = spec.get('noarch', defaults['noarch'])
+    if noarch:
+        noarch_include.append({'name': name})
+    else:
+        platforms = spec.get('platforms', defaults['platforms'])
+        pythons   = spec.get('pythons',   defaults['pythons'])
+        for platform in platforms:
+            os_info = PLATFORM_OS_MAP[platform]
+            for python in pythons:
+                arch_include.append({
+                    'name':     name,
+                    'os':       os_info['os'],
+                    'arch':     os_info['arch'],
+                    'python':   python,
+                    'platform': platform,
+                })
+
+print(f"arch_matrix={json.dumps({'include': arch_include})}")
+print(f"noarch_matrix={json.dumps({'include': noarch_include})}")

--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build (Windows)
         if: runner.os == 'Windows'
-        shell: cmd /C CALL {0}
+        shell: pwsh
         run: |
           python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
 

--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -58,18 +58,21 @@ jobs:
           architecture: ${{ matrix.arch }}
           auto-activate: true
 
+      - name: Install setuptools-conda
+        shell: bash -l {0}
+        run: |
+          conda install -c labscript-suite setuptools-conda
+
       - name: Build (Unix)
         if: runner.os != 'Windows'
         shell: bash -l {0}
         run: |
-          conda install -c labscript-suite setuptools-conda
           python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
 
       - name: Build (Windows)
         if: runner.os == 'Windows'
         shell: cmd /C CALL {0}
         run: |
-          conda install -c labscript-suite setuptools-conda && ^
           python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
 
       - uses: actions/upload-artifact@v7
@@ -105,10 +108,14 @@ jobs:
           conda-remove-defaults: true
           auto-activate: true
 
-      - name: Build noarch package
+      - name: Install setuptools-conda
         shell: bash -l {0}
         run: |
           conda install -c labscript-suite setuptools-conda
+
+      - name: Build noarch package
+        shell: bash -l {0}
+        run: |
           python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -85,7 +85,9 @@ jobs:
             $_ -notmatch "MongoDB" -and
             $_ -notmatch "ImageMagick" -and
             $_ -notmatch "Java" -and
-            $_ -notmatch "SQL Server"
+            $_ -notmatch "SQL Server" -and
+            $_ -notmatch "Chocolatey" -and
+            $_ -notmatch "MySQL"
           }
 
           $newPath = $filteredPath -join ';'
@@ -100,6 +102,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          Write-Host "Current PATH length: $($env:PATH.Length): $($env:PATH)"
           python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -21,7 +21,7 @@ jobs:
       noarch_matrix: ${{ steps.gen.outputs.noarch_matrix }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - run: pip install toml

--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -2,62 +2,53 @@ name: Make and upload Conda packages
 
 on:
   push:
-    branches:
-      - main
-    tags:
-      - '*'
+    branches: [update-workflows]
+    tags: ['*']
   schedule:
-    # - cron: '0-59/5 * * * *' # Every 5 minutes
-    - cron: '13 02 * * 1' # Weekly, 2:13AM Mondays UTC
+    - cron: '13 02 * * 1'   # Weekly, 2:13 AM Mondays UTC
 
 env:
   ANACONDA_USER: rydiqule
 
 jobs:
-  build:
-    name: Build
+
+  # ── Step 1: read pkgs.toml and emit two matrices ───────────────────────────
+  configure:
+    name: Configure build matrices
+    runs-on: ubuntu-latest
+    outputs:
+      arch_matrix:   ${{ steps.gen.outputs.arch_matrix }}
+      noarch_matrix: ${{ steps.gen.outputs.noarch_matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install toml
+      - id: gen
+        run: python .github/workflows/gen_matrix.py >> "$GITHUB_OUTPUT"
+
+  # ── Step 2a: one runner per (package × os × python) ────────────────────────
+  build-arch:
+    name: Build ${{ matrix.name }} – ${{ matrix.os }} py${{ matrix.python }}
+    needs: configure
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - { os: ubuntu-latest,   python: '3.14',  arch: x64}
-          - { os: ubuntu-latest,   python: '3.13',  arch: x64}
-          - { os: ubuntu-latest,   python: '3.12',  arch: x64}
-          - { os: ubuntu-latest,   python: '3.11',  arch: x64}
-          - { os: ubuntu-latest,   python: '3.10',  arch: x64 }
-
-          - { os: macos-latest,    python: '3.14',  arch: arm64}
-          - { os: macos-latest,    python: '3.13',  arch: arm64}
-          - { os: macos-latest,    python: '3.12',  arch: arm64}
-          - { os: macos-latest,    python: '3.11',  arch: arm64}
-          - { os: macos-latest,    python: '3.10',  arch: arm64}
-
-          - { os: windows-latest,  python: '3.14',  arch: x64 }
-          - { os: windows-latest,  python: '3.13',  arch: x64 }
-          - { os: windows-latest,  python: '3.12',  arch: x64 }
-          - { os: windows-latest,  python: '3.11',  arch: x64 }
-          - { os: windows-latest,  python: '3.10',  arch: x64 }
+      matrix: ${{ fromJSON(needs.configure.outputs.arch_matrix) }}
 
     if: github.repository == 'QTC-UMD/rydiqule-vendored-conda-builds'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Checkout latest tag
+      - name: Checkout latest tag (scheduled runs)
         if: github.event_name == 'schedule'
         shell: bash -l {0}
         run: git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
 
-      - name: Set BUILD_NOARCH=true
-        if: strategy.job-index == 0
-        shell: bash -l {0}
-        run: echo "BUILD_NOARCH=true" >> $GITHUB_ENV
-
-      - name: Install Miniforge
-        uses: conda-incubator/setup-miniconda@v4
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: "latest"
           channels: conda-forge
@@ -67,42 +58,83 @@ jobs:
           architecture: ${{ matrix.arch }}
           auto-activate: true
 
-      - name: Conda package (Unix)
+      - name: Build (Unix)
         if: runner.os != 'Windows'
         shell: bash -l {0}
         run: |
           conda install -c labscript-suite setuptools-conda
-          python make_packages.py ${{ runner.temp }}
+          python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
 
-      - name: Conda Package (Windows)
+      - name: Build (Windows)
         if: runner.os == 'Windows'
         shell: cmd /C CALL {0}
         run: |
           conda install -c labscript-suite setuptools-conda && ^
-          python make_packages.py ${{ runner.temp }}
+          python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
 
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v7
-        with: # v4 requires all artifact names are unique on upload
-          name: conda_packages-${{ matrix.os }}-py${{ matrix.python }}-${{ matrix.arch }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: conda_packages-${{ matrix.name }}-${{ matrix.os }}-py${{ matrix.python }}-${{ matrix.arch }}
           path: ./conda_packages
 
-  upload:
-    name: Upload
+  # ── Step 2b: one runner per noarch package (OS/Python don't matter) ─────────
+  build-noarch:
+    name: Build ${{ matrix.name }} – noarch
+    needs: configure
     runs-on: ubuntu-latest
-    needs: build
-    if: ${{ always() && contains(join(needs.build.result, ','), 'success') }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.configure.outputs.noarch_matrix) }}
+
+    if: github.repository == 'QTC-UMD/rydiqule-vendored-conda-builds'
     steps:
-      
-      - name: Download All Artifacts
-        uses: actions/download-artifact@v8
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout latest tag (scheduled runs)
+        if: github.event_name == 'schedule'
+        shell: bash -l {0}
+        run: git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
+
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: "latest"
+          channels: conda-forge
+          auto-update-conda: true
+          conda-remove-defaults: true
+          auto-activate: true
+
+      - name: Build noarch package
+        shell: bash -l {0}
+        run: |
+          conda install -c labscript-suite setuptools-conda
+          python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: conda_packages-${{ matrix.name }}-noarch
+          path: ./conda_packages
+
+  # ── Step 3: upload once all build jobs succeed (or at least one did) ────────
+  upload:
+    name: Upload to Anaconda
+    runs-on: ubuntu-latest
+    needs: [build-arch, build-noarch]
+    if: >-
+      always() &&
+      (
+        contains(join(needs.build-arch.result,   ','), 'success') ||
+        contains(join(needs.build-noarch.result, ','), 'success')
+      )
+    steps:
+      - uses: actions/download-artifact@v4
         with:
           pattern: conda_packages-*
           path: ./conda_packages
           merge-multiple: true
 
-      - name: Install Miniconda
-        uses: conda-incubator/setup-miniconda@v4
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: "latest"
           auto-update-conda: true
@@ -114,19 +146,7 @@ jobs:
         shell: bash -l {0}
         run: conda install anaconda-client
 
-      # - name: Publish to Anaconda test label
-      #   if: github.event.ref_type != 'tag' && github.event_name != 'schedule'
-      #   shell: bash -l {0}
-      #   run: |
-      #     anaconda \
-      #       --token ${{ secrets.ANACONDA_API_TOKEN }} \
-      #       upload \
-      #       --user $ANACONDA_USER \
-      #       --label test \
-      #       --skip-existing \
-      #       conda_packages/*/*
-
-      - name: Publish to Anaconda main label
+      - name: Publish to Anaconda (main label)
         if: (github.event_name == 'push' && contains(github.ref, '/tags')) || github.event_name == 'schedule'
         shell: bash -l {0}
         run: |

--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -70,16 +70,14 @@ jobs:
           python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
 
       - name: Trim Windows Path
+        # necessary to keep the conda build command short enough to run when building arc
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $pathArray = $env:PATH -split ';'
 
           Write-Host "Original PATH length: $($env:PATH.Length)"
-          Write-Host "Total Number of Entries: $($pathArray.Count)"
-          Write-Host "`nDirectory List:"
-          $pathArray | Select-Object @{Name="Length"; Expression={$_.Length}}, @{Name="Path"; Expression={$_}} | Sort-Object Length -Descending | Format-Table -AutoSize
-
+          
           # Define patterns to exclude
           $filteredPath = $pathArray | Where-Object {
             $_ -notmatch "MongoDB" -and
@@ -97,12 +95,15 @@ jobs:
           echo "PATH=$newPath" >> $env:GITHUB_ENV
 
           Write-Host "Trimmed PATH length: $($newPath.Length)"
+          Write-Host "Total Number of Entries: $($filteredPath.Count)"
+          Write-Host "`nDirectory List:"
+          $filteredPath | Select-Object @{Name="Length"; Expression={$_.Length}}, @{Name="Path"; Expression={$_}} | Sort-Object Length -Descending | Format-Table -AutoSize
 
       - name: Build (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Write-Host "Current PATH length: $($env:PATH.Length): $($env:PATH)"
+          Write-Host "Current PATH length: $($env:PATH.Length)"
           python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -20,7 +20,7 @@ jobs:
       arch_matrix:   ${{ steps.gen.outputs.arch_matrix }}
       noarch_matrix: ${{ steps.gen.outputs.noarch_matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
@@ -39,7 +39,7 @@ jobs:
 
     if: github.repository == 'QTC-UMD/rydiqule-vendored-conda-builds'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
         shell: bash -l {0}
         run: git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: "latest"
           channels: conda-forge
@@ -72,7 +72,7 @@ jobs:
           conda install -c labscript-suite setuptools-conda && ^
           python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: conda_packages-${{ matrix.name }}-${{ matrix.os }}-py${{ matrix.python }}-${{ matrix.arch }}
           path: ./conda_packages
@@ -88,7 +88,7 @@ jobs:
 
     if: github.repository == 'QTC-UMD/rydiqule-vendored-conda-builds'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -97,7 +97,7 @@ jobs:
         shell: bash -l {0}
         run: git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: "latest"
           channels: conda-forge
@@ -111,7 +111,7 @@ jobs:
           conda install -c labscript-suite setuptools-conda
           python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: conda_packages-${{ matrix.name }}-noarch
           path: ./conda_packages
@@ -128,13 +128,13 @@ jobs:
         contains(join(needs.build-noarch.result, ','), 'success')
       )
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: conda_packages-*
           path: ./conda_packages
           merge-multiple: true
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: "latest"
           auto-update-conda: true

--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -69,6 +69,28 @@ jobs:
         run: |
           python make_packages.py ${{ runner.temp }} --package "${{ matrix.name }}"
 
+      - name: Trim Windows Path
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $pathArray = $env:PATH -split ';'
+
+          # Define patterns to exclude
+          $filteredPath = $pathArray | Where-Object {
+            $_ -notmatch "Chocolatey" -and
+            $_ -notmatch "Android" -and
+            $_ -notmatch "SQL Server"
+          }
+
+          $newPath = $filteredPath -join ';'
+
+          # Apply to current session and export for following steps
+          $env:PATH = $newPath
+          echo "PATH=$newPath" >> $env:GITHUB_ENV
+
+          Write-Host "Original PATH length: $($env:PATH.Length)"
+          Write-Host "Trimmed PATH length: $($newPath.Length)"
+
       - name: Build (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -2,7 +2,7 @@ name: Make and upload Conda packages
 
 on:
   push:
-    branches: [update-workflows]
+    branches: [main]
     tags: ['*']
   schedule:
     - cron: '13 02 * * 1'   # Weekly, 2:13 AM Mondays UTC

--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -75,11 +75,17 @@ jobs:
         run: |
           $pathArray = $env:PATH -split ';'
 
+          Write-Host "Original PATH length: $($env:PATH.Length)"
+          Write-Host "Total Number of Entries: $($pathArray.Count)"
+          Write-Host "`nDirectory List:"
+          $pathArray | Select-Object @{Name="Length"; Expression={$_.Length}}, @{Name="Path"; Expression={$_}} | Sort-Object Length -Descending | Format-Table -AutoSize
+
           # Define patterns to exclude
           $filteredPath = $pathArray | Where-Object {
             $_ -notmatch "MongoDB" -and
             $_ -notmatch "ImageMagick" -and
-            $_ -notmatch "Java"
+            $_ -notmatch "Java" -and
+            $_ -notmatch "SQL Server"
           }
 
           $newPath = $filteredPath -join ';'
@@ -88,12 +94,7 @@ jobs:
           $env:PATH = $newPath
           echo "PATH=$newPath" >> $env:GITHUB_ENV
 
-          Write-Host "Original PATH length: $($env:PATH.Length)"
           Write-Host "Trimmed PATH length: $($newPath.Length)"
-          Write-Host "Total Number of Entries: $($newPath.Count)"
-          Write-Host "`nDirectory List:"
-
-          $pathArray | Select-Object @{Name="Length"; Expression={$_.Length}}, @{Name="Path"; Expression={$_}} | Sort-Object Length -Descending | Format-Table -AutoSize
 
       - name: Build (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -77,9 +77,9 @@ jobs:
 
           # Define patterns to exclude
           $filteredPath = $pathArray | Where-Object {
-            $_ -notmatch "Chocolatey" -and
-            $_ -notmatch "Android" -and
-            $_ -notmatch "SQL Server"
+            $_ -notmatch "MongoDB" -and
+            $_ -notmatch "ImageMagick" -and
+            $_ -notmatch "Java"
           }
 
           $newPath = $filteredPath -join ';'
@@ -90,6 +90,10 @@ jobs:
 
           Write-Host "Original PATH length: $($env:PATH.Length)"
           Write-Host "Trimmed PATH length: $($newPath.Length)"
+          Write-Host "Total Number of Entries: $($newPath.Count)"
+          Write-Host "`nDirectory List:"
+
+          $pathArray | Select-Object @{Name="Length"; Expression={$_.Length}}, @{Name="Path"; Expression={$_}} | Sort-Object Length -Descending | Format-Table -AutoSize
 
       - name: Build (Windows)
         if: runner.os == 'Windows'

--- a/make_packages.py
+++ b/make_packages.py
@@ -111,6 +111,9 @@ def build_conda_package(name, spec):
         if PY not in pythons:
             print(f"Skipping {name} as {PY} is not in its list of Python versions")
             return
+        
+    print(f'=====> Building {name:s} with options:')
+    print(f'\t\t{version=}\n\t\t{source=}\n\t\t{build_args=}\n\t\t{noarch=}\n\t\t{pythons=}\n\t\t{platforms=}')
 
     # Download it:
     project_dir = download(name, source, version)

--- a/make_packages.py
+++ b/make_packages.py
@@ -102,10 +102,7 @@ def build_conda_package(name, spec):
     pythons = spec.get('pythons', defaults['pythons'])
     platforms = spec.get('platforms', defaults['platforms'])
 
-    if noarch and not os.getenv('BUILD_NOARCH'):
-        print(f"Skipping {name} as it is noarch but BUILD_NOARCH env var is not set")
-        return
-    elif not noarch:
+    if not noarch:
         if PLATFORM not in platforms:
             print(f"Skipping {name} as {PLATFORM} is not in its list of platforms")
             return

--- a/make_packages.py
+++ b/make_packages.py
@@ -147,6 +147,14 @@ def build_conda_package(name, spec):
 
 
 if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('build_dir', nargs='?', default='build')
+    parser.add_argument('--package', default=None,
+                        help='Only build this specific package (by TOML key)')
+    args = parser.parse_args()
+    BUILD_DIR = args.build_dir  # reassign the module-level var
+
     Path(BUILD_DIR).mkdir(exist_ok=True)
     packages = toml.load('pkgs.toml')
     defaults = packages['defaults']
@@ -154,5 +162,6 @@ if __name__ == '__main__':
     for name, spec in packages.items():
         if name == 'defaults':
             continue
-
+        if args.package and name != args.package:
+            continue
         build_conda_package(name, spec)

--- a/make_packages.py
+++ b/make_packages.py
@@ -58,6 +58,7 @@ def download(name, source, version):
         download_cmd = [
             'pip',
             'download',
+            '-v',
             '--no-binary=:all:',
             '--no-build-isolation',
             '--no-deps',

--- a/pkgs.toml
+++ b/pkgs.toml
@@ -13,7 +13,7 @@ source = "git+https://github.com/jrenaud90/CyRK/"
 noarch = false
 build_args = ["--license=CC-BY-SA", # override so full license text not used
               "--from-downloaded-wheel", # non-standard build, use pip wheels
-              '--setup-requires="cython>=3.0.0","numpy<2.4",python-gil', # python-gil ensures free-threaded python not grabbed by dependency
+              '--setup-requires=cython>=3.0.0,numpy<2.4,python-gil', # python-gil ensures free-threaded python not grabbed by dependency
               "--ignore-run-exports=python,numpy"] # prevents runtime dependencies being hash locked
               
 # CC BY-SA 4.0
@@ -22,7 +22,7 @@ build_args = ["--license=CC-BY-SA", # override so full license text not used
 source = "git+https://github.com/nikolasibalic/ARC-Alkali-Rydberg-Calculator/"
 noarch = false
 build_args = ['--from-downloaded-wheel', # conda-build not working on windows
-              "--setup-requires='numpy>=2.0.0',python-gil", # python-gil ensures free-threaded python not grabbed by dependency
+              "--setup-requires=numpy>=2.0.0,python-gil", # python-gil ensures free-threaded python not grabbed by dependency
               "--ignore-run-exports=python,numpy,libstdcxx"]
 # BSD3
 

--- a/pkgs.toml
+++ b/pkgs.toml
@@ -13,13 +13,14 @@ source = "git+https://github.com/jrenaud90/CyRK/"
 noarch = false
 build_args = ["--license=CC-BY-SA", # override so full license text not used
               "--from-downloaded-wheel", # non-standard build, use pip wheels
-              "--conda-name-differences=python:python-gil"] # python-gil ensures free-threaded python not grabbed
+              "--conda-name-differences=python:python-gil"] # python-gil ensures free-threaded python not grabbed by dependency
 # CC BY-SA 4.0
 
 [ARC-Alkali-Rydberg-Calculator]
 source = "git+https://github.com/nikolasibalic/ARC-Alkali-Rydberg-Calculator/"
 noarch = false
-build_args = ['--from-downloaded-wheel'] # conda-build not working on windows
+build_args = ['--from-downloaded-wheel', # conda-build not working on windows
+              "--conda-name-differences=python:python-gil"] # python-gil ensures free-threaded python not grabbed by dependency
 # BSD3
 
 [leveldiagram]

--- a/pkgs.toml
+++ b/pkgs.toml
@@ -13,14 +13,17 @@ source = "git+https://github.com/jrenaud90/CyRK/"
 noarch = false
 build_args = ["--license=CC-BY-SA", # override so full license text not used
               "--from-downloaded-wheel", # non-standard build, use pip wheels
-              "--conda-name-differences=python:python-gil"] # python-gil ensures free-threaded python not grabbed by dependency
+              '--setup-requires="cython>=3.0.0","numpy<2.4",python-gil', # python-gil ensures free-threaded python not grabbed by dependency
+              "--ignore-run-exports=python,numpy"] # prevents runtime dependencies being hash locked
+              
 # CC BY-SA 4.0
 
 [ARC-Alkali-Rydberg-Calculator]
 source = "git+https://github.com/nikolasibalic/ARC-Alkali-Rydberg-Calculator/"
 noarch = false
 build_args = ['--from-downloaded-wheel', # conda-build not working on windows
-              "--conda-name-differences=python:python-gil"] # python-gil ensures free-threaded python not grabbed by dependency
+              "--setup-requires='numpy>=2.0.0',python-gil", # python-gil ensures free-threaded python not grabbed by dependency
+              "--ignore-run-exports=python,numpy,libstdcxx"]
 # BSD3
 
 [leveldiagram]

--- a/pkgs.toml
+++ b/pkgs.toml
@@ -12,7 +12,8 @@ platforms = ["win-64", "osx-arm64", "linux"]
 source = "git+https://github.com/jrenaud90/CyRK/"
 noarch = false
 build_args = ["--license=CC-BY-SA", # override so full license text not used
-              "--from-downloaded-wheel"] # non-standard build, use pip wheels
+              "--from-downloaded-wheel", # non-standard build, use pip wheels
+              "--conda-name-differences=python:python-gil"] # python-gil ensures free-threaded python not grabbed
 # CC BY-SA 4.0
 
 [ARC-Alkali-Rydberg-Calculator]


### PR DESCRIPTION
Splits out every build into its own runner (ie package-platform-{python}). Also fixes build issues with free-threaded python3.14 for compiled builds and a PATH variable too long issue for the Windows runners when building ARC-Alkali-Rydberg-Calculator.